### PR TITLE
Fix blog link path in header component

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -37,7 +37,7 @@ if (typeof window !== "undefined") {
     <div class="text-center pb-1 pt-3 border-b-gray-200 border-b-1 w-3/4 mx-auto">
         <p>
             Check out my latest blog post:
-            <a href="/MC-site/blog/HowToPZServer" class="hover:underline">
+            <a href="/blog/HowToPZServer" class="hover:underline">
                 How to create a free Project Zomboid server using Oracle Cloud's
                 free tier services
             </a>


### PR DESCRIPTION
This PR corrects the blog link in the header by changing the URL from 
'/MC-site/blog/HowToPZServer' to '/blog/HowToPZServer'. This update 
reflects the recent site structure changes.